### PR TITLE
Possibility to override the default menu item entity.

### DIFF
--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -26,7 +26,7 @@
                  class="%ktw_database_menu.menu_item_repository_class%"
                  factory-service="doctrine.orm.entity_manager"
                  factory-method="getRepository">
-            <argument>kevintweber\KtwDatabaseMenuBundle\Entity\MenuItem</argument>
+            <argument>%ktw_database_menu.menu_item_entity%</argument>
         </service>
 
         <service id="ktw_database_menu.provider" class="%ktw_database_menu.provider_class%">


### PR DESCRIPTION
This allows to prevent `MappingException: Class 'kevintweber\KtwDatabasemenuBundle\Entity\MenuItem' does not exist` when Doctrine `auto_mapping` is set to `false` and custom menu item entity is using.