### PR TITLE
Possibility to override the default table name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('menu_item_entity')
                     ->defaultValue('kevintweber\KtwDatabaseMenuBundle\Entity\MenuItem')
                 ->end()
+                ->scalarNode('table_name')
+                    ->defaultValue('ktw_menu_items')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/EventListener/MappingListener.php
+++ b/EventListener/MappingListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace kevintweber\KtwDatabaseMenuBundle\EventListener;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+/**
+ * Class MappingListener
+ *
+ * @author  emulienfou <david38sanchez@gmail.com>
+ * @package kevintweber\KtwDatabaseMenuBundle\EventListener
+ */
+class MappingListener
+{
+
+    protected $tableName;
+
+    /**
+     * MappingListener constructor.
+     *
+     * @param string $tableName
+     */
+    public function __construct($tableName)
+    {
+        $this->tableName = $tableName;
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+        $table         = $classMetadata->table;
+
+        // Update table name from configuration
+        $table['name'] = $this->tableName;
+        $classMetadata->setPrimaryTable($table);
+    }
+}

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -9,6 +9,7 @@
         <parameter key="ktw_database_menu.factory_class">kevintweber\KtwDatabaseMenuBundle\Menu\DatabaseMenuFactory</parameter>
         <parameter key="ktw_database_menu.provider_class">kevintweber\KtwDatabaseMenuBundle\Provider\DatabaseMenuProvider</parameter>
         <parameter key="ktw_database_menu.menu_item_repository_class">kevintweber\KtwDatabaseMenuBundle\Repository\MenuItemRepository</parameter>
+        <parameter key="ktw_database_menu.mapping_listener_class">kevintweber\KtwDatabaseMenuBundle\EventListener\MappingListener</parameter>
     </parameters>
 
     <services>
@@ -31,6 +32,11 @@
         <service id="ktw_database_menu.provider" class="%ktw_database_menu.provider_class%">
             <argument type="service" id="ktw_database_menu.menu_item_repository" />
             <tag name="knp_menu.provider" />
+        </service>
+
+        <service id="mapping.listener" class="%ktw_database_menu.mapping_listener_class%" public="false">
+            <argument>%ktw_database_menu.table_name%%</argument>
+            <tag name="doctrine.event_listener" event="loadClassMetadata"/>
         </service>
     </services>
 </container>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -75,6 +75,7 @@ All available configuration options are listed here with their default values:
 # app/config/config.yml
 ktw_database_menu:
     menu_item_entity: kevintweber\KtwDatabaseMenuBundle\Entity\MenuItem
+    table_name: menu_items
 ```
 
 In case you want to extend the functionality of the MenuItem entity, you


### PR DESCRIPTION
This allow user to change the name of the default table name created by the bundle.

By default the bundle will add a new table to your database called **ktw_menu_items**.

This PR allow user to change the table name using a new configuration key:
```yml
# app/config/config.yml
ktw_database_menu:
    table_name: menu_items
```